### PR TITLE
Qop selection

### DIFF
--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -494,6 +494,19 @@ class GSSAPIMechanism(Mechanism):
         max_length, = struct.unpack('!i', '\x00' + plaintext_data[1:])
         self.max_buffer = min(self.sasl.max_buffer, max_length)
 
+        """
+        Construct the reply.
+
+        byte 0: the selected qop. 1==auth, 2==auth-int, 4==auth-conf
+        byte 1-3: the max length for any buffer sent back and forth on
+            this connection. (big endian)
+        the rest of the buffer: the authorization user name in UTF-8 -
+            not null terminated.
+
+        So, we write the max length and authorization user name first, then
+        overwrite the first byte of the buffer with the qop.  This is ok since
+        the max length is writen out in big endian.
+        """
         i = len(self.user)
         fmt = '!I' + str(i) + 's'
         outdata = create_string_buffer(4 + i)


### PR DESCRIPTION
I needed to provide three fixes:  First, I needed to fix the negotiation of the qop between the client and the server.  I went with the option of composing the final sasl negotiation message in pure-sasl instead of letting PyKerberos do it because the code for this negotiation is a SASL thing and thus belongs in the library providing SASL, not the library providing generic Kerberos functionality.

Next I needed to fix the wrap and unwrap calls (there was a syntax error).

Finally, in order to allow the client to choose auth-conf, I needed to pass a flag into the gss_wrap call in PyKerberos to indicate that the message should be encrypted as well as integrity protected.  This final fix required changes to both pure-sasl and PyKerberos.
