### PR TITLE
Switching order of service and host for digest-uri

### DIFF
--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -293,7 +293,8 @@ class DigestMD5Mechanism(Mechanism):
         self.nc += 1
         resp['nc'] = bytes('%08x' % self.nc)
 
-        self._digest_uri = bytes(self.sasl.host) + b'/' + bytes(self.sasl.service)
+        self._digest_uri = bytes(self.sasl.service) + b'/' + \
+                                                        bytes(self.sasl.host)
         resp['digest-uri'] = quote(self._digest_uri)
 
         a2 = b'AUTHENTICATE:' + self._digest_uri


### PR DESCRIPTION
The order of service and host was inverted. Just changing that I could use it for my XMPP implementation.

Here (line 76) you can also see how it's implemented in twisted: http://twistedmatrix.com/trac/browser/tags/releases/twisted-8.2.0/twisted/words/protocols/jabber/sasl_mechanisms.py#L76
