### PR TITLE
Add AUTHZID support for PLAIN mechanism.

### DIFF
--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -135,14 +135,15 @@ class PlainMechanism(Mechanism):
 
     allows_anonymous = False
 
-    def __init__(self, sasl, username=None, password=None, **props):
+    def __init__(self, sasl, username=None, password=None, identity='', **props):
         Mechanism.__init__(self, sasl)
+        self.identity = identity
         self.username = username
         self.password = password
 
     def process(self, challenge=None):
         self._fetch_properties('username', 'password')
-        return b'\x00' + bytes(self.username) + b'\x00' + bytes(self.password)
+        return bytes(self.identity) + b'\x00' + bytes(self.username) + b'\x00' + bytes(self.password)
 
     def dispose(self):
         self.password = None


### PR DESCRIPTION
This change adds support for authenticating for a different authorization identity (AUTHZID) using the normal username (AUTHCID) and password attributes, for the PLAIN mechanism. It adds a single attribute called `identity` to the constructor, which is empty by default (corresponding to 'same as AUTHCID' in SASL PLAIN).

See also: http://www.ietf.org/rfc/rfc4616.txt, section 2.
