### PR TITLE
Restore DIGEST-MD5 auth support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ pure-sasl
 pure-sasl is a pure python client-side SASL implementation.
 
 At the moment, it supports the following mechanisms: ANONYMOUS, PLAIN,
-CRAM-MD5, and GSSAPI. Support for other mechanisms may be added in the
-future.
+CRAM-MD5, DIGEST-MD5, and GSSAPI. Support for other mechanisms may be added in the
+future. Only GSSAPI supports a QOP higher than auth. Always use TLS!
 
 Both Python 2 and Python 3 are supported.
 

--- a/puresasl/client.py
+++ b/puresasl/client.py
@@ -175,6 +175,11 @@ class SASLClient(object):
         """
         self._chosen_mech.dispose()
 
+    @property
+    @_require_mech
+    def qop(self):
+        return self._chosen_mech.qop
+
     def choose_mechanism(self, mechanism_choices, allow_anonymous=True,
                          allow_plaintext=True, allow_active=True,
                          allow_dictionary=True):

--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -4,6 +4,7 @@ import hmac
 import random
 import struct
 import sys
+import six
 
 from puresasl import SASLError, SASLProtocolException, QOP
 
@@ -121,9 +122,8 @@ class Mechanism(object):
                                         "protection is one of (%s), the server is "
                                         "offering (%s), and %s supports (%s)" % (user, offered, self.name, supported))
         else:
-            self.qops = available_qops
             for qop in (QOP.AUTH_CONF, QOP.AUTH_INT, QOP.AUTH):
-                if qop in self.qops:
+                if qop in available_qops:
                     self.qop = qop
                     break
 
@@ -222,7 +222,7 @@ def bytes(text):
             return builtins.bytes(text)
         else:
             # Convert UTF-8 text to bytes
-            return builtins.bytes(text, encoding='utf-8')
+            return builtins.bytes(six.text_type(text), encoding='utf-8')
 
 
 def quote(text):

--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -201,7 +201,251 @@ class DigestMD5Mechanism(Mechanism):
     dec_magic = 'Digest session key to server-to-client signing key magic'
 
     def __init__(self, sasl, username=None, password=None, **props):
-        raise NotImplementedError("Digest MD5 mechanism is not yet supported")
+        Mechanism.__init__(self, sasl)
+        self.username = username
+        self.password = password
+
+        self.qops = self.sasl.qops
+        self.qop = b'auth'
+        self.max_buffer = self.sasl.max_buffer
+
+        self._rspauth_okay = False
+        self._digest_uri = None
+        self._a1 = None
+        self._enc_buf = b''
+        self._enc_key = None
+        self._enc_seq = 0
+        self._dec_buf = b''
+        self._dec_key = None
+        self._dec_seq = 0
+
+    def dispose(self):
+        self._rspauth_okay = None
+        self._digest_uri = None
+        self._a1 = None
+        self._enc_buf = b''
+        self._enc_key = None
+        self._enc_seq = 0
+        self._dec_buf = b''
+        self._dec_key = None
+        self._dec_seq = 0
+
+        self.password = None
+        self.key_hash = None
+        self.realm = None
+        self.nonce = None
+        self.cnonce = None
+        self.nc = 0
+
+    def _MAC(self, seq, msg, key):
+        """
+        """
+        mac = hmac.HMAC(key=key, digestmod=hashlib.md5)
+        seqnum = num_to_bytes(seq)
+        mac.update(seqnum)
+        mac.update(msg)
+        return mac.digest()[:10] + b'\x00\x01' + seqnum
+
+    def wrap(self, outgoing):
+        result = b''
+        # Leave buffer space for the MAC
+        mbuf = self.max_buffer - 10 - 2 - 4
+
+        while outgoing:
+            msg = outgoing[:mbuf]
+            mac = self._MAC(self._enc_seq, msg, self._enc_key)
+            self._enc_seq += 1
+            msg += mac
+            result += num_to_bytes(len(msg)) + msg
+            outgoing = outgoing[mbuf:]
+
+        return result
+
+    def unwrap(self, incoming):
+        """
+        """
+        incoming = b'' + incoming
+        result = b''
+
+        while len(incoming) > 4:
+            num = bytes_to_num(incoming)
+            if len(incoming) < (num + 4):
+                return result
+
+            mac = incoming[4:4 + num]
+            incoming[4 + num:]
+            msg = mac[:-16]
+
+            mac_conf = self._MAC(self._dec_mac, msg, self._dec_key)
+            if mac[-16:] != mac_conf:
+                self._desc_sec = None
+                return result
+
+            self._dec_seq += 1
+            result += msg
+
+        return result
+
+    def response(self):
+        required_props = ['username']
+        if not getattr(self, 'key_hash', None):
+            required_props.append('password')
+        self._fetch_properties(*required_props)
+
+        resp = {}
+        if 'auth-int' in self.qops:
+            self.qop = b'auth-int'
+        resp['qop'] = self.qop
+
+        if getattr(self, 'realm', None) is not None:
+            resp['realm'] = quote(self.realm)
+
+        resp['username'] = quote(bytes(self.username))
+        resp['nonce'] = quote(self.nonce)
+        if self.nc == 0:
+            self.cnonce = bytes('%s' % random.random())[2:]
+        resp['cnonce'] = quote(self.cnonce)
+        self.nc += 1
+        resp['nc'] = bytes('%08x' % self.nc)
+
+        self._digest_uri = bytes(self.sasl.service) + b'/' + \
+                                                        bytes(self.sasl.host)
+        resp['digest-uri'] = quote(self._digest_uri)
+
+        a2 = b'AUTHENTICATE:' + self._digest_uri
+        if self.qop != b'auth':
+            a2 += b':00000000000000000000000000000000'
+            resp['maxbuf'] = b'16777215'  # 2**24-1
+        resp['response'] = self.gen_hash(a2)
+        return b','.join([bytes(k) + b'=' + bytes(v) for k, v in resp.items()])
+
+    def parse_challenge(self, challenge):
+        ret = {}
+        var = b''
+        val = b''
+        in_var = True
+        in_quotes = False
+        new = False
+        escaped = False
+        for c in challenge:
+            if sys.version_info >= (3, 0):
+                c = bytes([c])
+            if in_var:
+                if c.isspace():
+                    continue
+                if c == b'=':
+                    in_var = False
+                    new = True
+                else:
+                    var += c
+            else:
+                if new:
+                    if c == b'"':
+                        in_quotes = True
+                    else:
+                        val += c
+                    new = False
+                elif in_quotes:
+                    if escaped:
+                        escaped = False
+                        val += c
+                    else:
+                        if c == b'\\':
+                            escaped = True
+                        elif c == b'"':
+                            in_quotes = False
+                        else:
+                            val += c
+                else:
+                    if c == b',':
+                        if var:
+                            ret[var] = val
+                        var = b''
+                        val = b''
+                        in_var = True
+                    else:
+                        val += c
+        if var:
+            ret[var] = val
+        return ret
+
+    def gen_hash(self, a2):
+        if not getattr(self, 'key_hash', None):
+            key_hash = hashlib.md5()
+            user = bytes(self.username)
+            password = bytes(self.password)
+            realm = bytes(self.realm)
+            kh = user + b':' + realm + b':' + password
+            key_hash.update(kh)
+            self.key_hash = key_hash.digest()
+
+        a1 = hashlib.md5(self.key_hash)
+        a1h = b':' + self.nonce + b':' + self.cnonce
+        a1.update(a1h)
+        response = hashlib.md5()
+        self._a1 = a1.digest()
+        rv = bytes(a1.hexdigest().lower())
+        rv += b':' + self.nonce
+        rv += b':' + bytes('%08x' % self.nc)
+        rv += b':' + self.cnonce
+        rv += b':' + self.qop
+        rv += b':' + bytes(hashlib.md5(a2).hexdigest().lower())
+        response.update(rv)
+        return bytes(response.hexdigest().lower())
+
+    def authenticate_server(self, cmp_hash):
+        a2 = b':' + self._digest_uri
+        if self.qop != b'auth':
+            a2 += b':00000000000000000000000000000000'
+        if self.gen_hash(a2) == cmp_hash:
+            self._rspauth_okay = True
+
+    def process(self, challenge=None):
+        if challenge is None:
+            needed = ['username', 'realm', 'nonce', 'key_hash',
+                      'nc', 'cnonce', 'qops']
+            if all(getattr(self, p, None) is not None for p in needed):
+                return self.response()
+            else:
+                return None
+
+        challenge_dict = self.parse_challenge(challenge)
+        if self.sasl.mutual_auth and b'rspauth' in challenge_dict:
+            self.authenticate_server(challenge_dict[b'rspauth'])
+        else:
+            if b'realm' not in challenge_dict:
+                self._fetch_properties('realm')
+                challenge_dict[b'realm'] = self.realm
+
+            for key in (b'nonce', b'realm'):
+                if key in challenge_dict:
+                    setattr(self, key, challenge_dict[key])
+
+            self.nc = 0
+            if b'qop' in challenge_dict:
+                server_offered_qops = [x.strip() for x in challenge_dict[b'qop'].split(b',')]
+            else:
+                server_offered_qops = [b'auth']
+            self._pick_qop(server_offered_qops)
+
+            if b'maxbuf' in challenge_dict:
+                self.max_buffer = min(
+                        self.sasl.max_buffer, int(challenge_dict[b'maxbuf']))
+
+            return self.response()
+
+    @property
+    def complete(self):
+        """
+        """
+        if not self.sasl.mutual_auth:
+            return True
+
+        if self._rspauth_okay and self.qop == b'auth-int':
+            self._enc_key = hashlib.md5(self._a1 + self.enc_magic).digest()
+            self._dec_key = hashlib.md5(self._a1 + self.dec_magic).digest()
+            self.encoding = True
+        return self._rspauth_okay
 
 
 class GSSAPIMechanism(Mechanism):

--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -114,11 +114,12 @@ class Mechanism(object):
         supported_qops = set(self.qops)
         available_qops = user_qops & supported_qops & server_qop_set
         if not available_qops:
-            configured = b', '.join(configured_qops).decode('ascii')
+            user = b', '.join(user_qops).decode('ascii')
+            supported = b', '.join(supported_qops).decode('ascii')
             offered = b', '.join(server_qop_set).decode('ascii')
             raise SASLProtocolException("Your requested quality of "
-                                        "protection is one of (%s), but the server is only "
-                                        "offering (%s)" % (configured, offered))
+                                        "protection is one of (%s), the server is "
+                                        "offering (%s), and %s supports (%s)" % (user, offered, self.name, supported))
         else:
             self.qops = available_qops
             for qop in (QOP.AUTH_CONF, QOP.AUTH_INT, QOP.AUTH):

--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -53,6 +53,8 @@ class Mechanism(object):
 
     def __init__(self, sasl, **props):
         self.sasl = sasl
+        self.qops = [QOP.AUTH]
+        self.qop = QOP.AUTH
 
     def process(self, challenge=None):
         """
@@ -154,8 +156,6 @@ class PlainMechanism(Mechanism):
         self.identity = identity
         self.username = username
         self.password = password
-        self.qops = [b'auth']
-        self.qop = b'auth'
 
     def process(self, challenge=None):
         self._fetch_properties('username', 'password')
@@ -177,8 +177,6 @@ class CramMD5Mechanism(PlainMechanism):
         Mechanism.__init__(self, sasl)
         self.username = username
         self.password = password
-        self.qops = [b'auth']
-        self.qop = b'auth'
 
     def process(self, challenge=None):
         if challenge is None:
@@ -257,8 +255,6 @@ class DigestMD5Mechanism(Mechanism):
         self.username = username
         self.password = password
 
-        self.qops = [b'auth']
-        self.qop = b'auth'
 
         self._rspauth_okay = False
         self._digest_uri = None
@@ -277,13 +273,13 @@ class DigestMD5Mechanism(Mechanism):
         self.nc = 0
 
     def wrap(self, outgoing):
-        if self.qop == 'auth-int' or self.qop == 'auth-conf':
+        if self.qop != QOP.AUTH:
             raise Exception('{0} QoP not supported for DIGEST-MD5'.format(self.qop))
         else:
             return outgoing
 
     def unwrap(self, incoming):
-        if self.qop == 'auth-int' or self.qop == 'auth-conf':
+        if self.qop != QOP.AUTH:
             raise Exception('{0} QoP not supported for DIGEST-MD5'.format(self.qop))
         else:
             return incoming
@@ -451,6 +447,7 @@ class GSSAPIMechanism(Mechanism):
         self.service = self.sasl.service
         self.principal = principal
         self._fetch_properties('host', 'service')
+        self.qops = QOP.all
 
         krb_service = '@'.join((self.service, self.host))
         try:

--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -104,7 +104,7 @@ class Mechanism(object):
         Choose a quality of protection based on the user's requirements and
         what the server supports.
         """
-        configured_qops = set(_b(qop) if isinstance(qop, str) else qop for qop in self.sasl.qops)  # normalize user-defined config
+        configured_qops = set(_b(qop) if isinstance(qop, str) else qop for qop in self.qops)  # normalize user-defined config
         available_qops = configured_qops & server_qop_set
         if not available_qops:
             configured = b', '.join(configured_qops).decode('ascii')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from distutils.core import setup
+from setuptools import setup
 
 import puresasl
 

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -24,6 +24,7 @@ from puresasl.mechanisms import AnonymousMechanism, PlainMechanism, GSSAPIMechan
 
 class _BaseMechanismTests(unittest.TestCase):
 
+    mechanism_class = AnonymousMechanism
     sasl_kwargs = {}
 
     def setUp(self):

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -48,7 +48,7 @@ class _BaseMechanismTests(unittest.TestCase):
         self.assertRaises(NotImplementedError, self.sasl.wrap, 'msg')
         self.assertRaises(NotImplementedError, self.sasl.unwrap, 'msg')
 
-    def test__pick_qop(self):
+    def test__pick_qop(self, *args):
         self.assertRaises(SASLProtocolException, self.sasl._chosen_mech._pick_qop, set())
         self.sasl._chosen_mech._pick_qop(set(QOP.all))
 

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -171,7 +171,28 @@ class CramMD5Mechanism(_BaseMechanismTests):
         self.assertIs(self.sasl.unwrap(msg), msg)
 
 
-class DigestMD5MechanismTest(unittest.TestCase):
+class DigestMD5MechanismTest(_BaseMechanismTests):
 
-    def test_not_implemented(self):
-        self.assertRaises(NotImplementedError, SASLClient, 'localhost', mechanism=DigestMD5Mechanism.name)
+    mechanism_class = DigestMD5Mechanism
+    username = 'user'
+    password = 'pass'
+    sasl_kwargs = {'username': username, 'password': password}
+
+    def test_wrap_unwrap(self):
+        msg = 'msg'
+        self.assertIs(self.sasl.wrap(msg), msg)
+        self.assertIs(self.sasl.unwrap(msg), msg)
+
+    def test_process_basic(self, *args):
+        pass
+
+    def test_process(self):
+        testChallenge = (
+            'nonce="rmD6R8aMYVWH+/ih9HGBr3xNGAR6o2DUxpKlgDz6gUQ=",r'
+            'ealm="example.org",qop="auth,auth-int,auth-conf",cipher="rc4-40,rc'
+            '4-56,rc4,des,3des",maxbuf=65536,charset=utf-8,algorithm=md5-sess'
+        )
+        self.sasl.process(testChallenge)
+
+    def test_qop(self):
+        self.assertEqual(self.sasl.qop, 'auth')

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -48,6 +48,10 @@ class _BaseMechanismTests(unittest.TestCase):
         self.assertRaises(NotImplementedError, self.sasl.wrap, 'msg')
         self.assertRaises(NotImplementedError, self.sasl.unwrap, 'msg')
 
+    def test__pick_qop(self):
+        self.assertRaises(SASLProtocolException, self.sasl._chosen_mech._pick_qop, set())
+        self.sasl._chosen_mech._pick_qop(set(QOP.all))
+
 
 class AnonymousMechanismTest(_BaseMechanismTests):
 
@@ -195,5 +199,7 @@ class DigestMD5MechanismTest(_BaseMechanismTests):
         )
         self.sasl.process(testChallenge)
 
-    def test_qop(self):
+    def test__pick_qop(self):
+        # _pick_qop is called by process for DigestMD5
+        # assert that it chose the only supported mech
         self.assertEqual(self.sasl.qop, QOP.AUTH)

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -196,4 +196,4 @@ class DigestMD5MechanismTest(_BaseMechanismTests):
         self.sasl.process(testChallenge)
 
     def test_qop(self):
-        self.assertEqual(self.sasl.qop, 'auth')
+        self.assertEqual(self.sasl.qop, QOP.AUTH)


### PR DESCRIPTION
Restoring the working auth QOP implementation for DIGEST-MD5, and cleaning up non-working/incomplete auth-int support. This aligns with the level of support for other mechs (other than GSSAPI).

DIGEST-MD5 has been tested against an LDAP server.