### PR TITLE
Add SASL authorization support

### DIFF
--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -165,7 +165,8 @@ class PlainMechanism(Mechanism):
     def process(self, challenge=None):
         self._fetch_properties('username', 'password')
         self.complete = True
-        return b''.join((_b(self.identity), b'\x00', _b(self.username), b'\x00', _b(self.password)))
+        auth_id = self.sasl.authorization_id or self.identity
+        return b''.join((_b(auth_id), b'\x00', _b(self.username), b'\x00', _b(self.password)))
 
     def dispose(self):
         self.password = None
@@ -485,10 +486,11 @@ class GSSAPIMechanism(Mechanism):
         the rest of the buffer: the authorization user name in UTF-8 -
             not null terminated.
         """
-        l = len(self.user)
+        auth_id = self.sasl.authorization_id or self.user
+        l = len(auth_id)
         fmt = '!I' + str(l) + 's'
         word = QOP.flag_from_name(self.qop) << 24 | self.max_buffer
-        out = struct.pack(fmt, word, _b(self.user),)
+        out = struct.pack(fmt, word, _b(auth_id),)
 
         encoded = base64.b64encode(out).decode('ascii')
 

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -88,7 +88,7 @@ class PlainTextMechanismTest(_BaseMechanismTests):
         sasl_kwargs.update({'authorization_id': auth_id})
         sasl = SASLClient('localhost', mechanism=self.mechanism_class.name, **sasl_kwargs)
         response = sasl.process(challenge)
-        self.assertEqual(response, b'%s\x00%s\x00%s' % (six.b(auth_id), six.b(self.username), six.b(self.password)))
+        self.assertEqual(response, six.b('{0}\x00{1}\x00{2}'.format(auth_id, self.username, self.password)))
         self.assertIsInstance(response, six.binary_type)
 
     def test_wrap_unwrap(self):

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -68,7 +68,7 @@ class PlainTextMechanismTest(_BaseMechanismTests):
     def test_process(self):
         for challenge in (None, '', b'asdf', u"\U0001F44D"):
             response = self.sasl.process(challenge)
-            self.assertEqual(response, b'\x00%s\x00%s' % (six.b(self.username), six.b(self.password)))
+            self.assertEqual(response, six.b('\x00{0}\x00{1}'.format(self.username, self.password)))
             self.assertIsInstance(response, six.binary_type)
 
     def test_process_with_authorization_id_or_identity(self):
@@ -80,7 +80,7 @@ class PlainTextMechanismTest(_BaseMechanismTests):
         sasl_kwargs.update({'identity': identity})
         sasl = SASLClient('localhost', mechanism=self.mechanism_class.name, **sasl_kwargs)
         response = sasl.process(challenge)
-        self.assertEqual(response, b'%s\x00%s\x00%s' % (six.b(identity), six.b(self.username), six.b(self.password)))
+        self.assertEqual(response, six.b('{0}\x00{1}\x00{2}'.format(identity, self.username, self.password)))
         self.assertIsInstance(response, six.binary_type)
 
         # Test that the sasl authorization_id has priority over identity


### PR DESCRIPTION
This add the sasl authorization id support for PlanText and GSSAPI. Before, it wasn't used at all. I haven't added tests for GSSAPI because these tests are mostly only mocking stuff.
