### PR TITLE
Fix QOP checks to be python3 compatible

### DIFF
--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -500,9 +500,9 @@ class GSSAPIMechanism(Mechanism):
         return base64.b64decode(response)
 
     def wrap(self, outgoing):
-        if self.qop != 'auth':
+        if self.qop != b'auth':
             outgoing = base64.b64encode(outgoing)
-            if self.qop == 'auth-conf':
+            if self.qop == b'auth-conf':
                 protect = 1
             else:
                 protect = 0
@@ -512,11 +512,11 @@ class GSSAPIMechanism(Mechanism):
             return outgoing
 
     def unwrap(self, incoming):
-        if self.qop != 'auth':
+        if self.qop != b'auth':
             incoming = base64.b64encode(incoming)
             kerberos.authGSSClientUnwrap(self.context, incoming)
             conf = kerberos.authGSSClientResponseConf(self.context)
-            if 0 == conf and self.qop == 'auth-conf':
+            if 0 == conf and self.qop == b'auth-conf':
                 raise Exception("Error: confidentiality requested, but not honored by the server.")
             return base64.b64decode(kerberos.authGSSClientResponse(self.context))
         else:

--- a/tests/unit/test_mechanism.py
+++ b/tests/unit/test_mechanism.py
@@ -110,17 +110,17 @@ if _have_kerberos:
         @patch('puresasl.mechanisms.kerberos.authGSSClientUnwrap')
         def test_wrap_unwrap(self, _inner1, _inner2, authGSSClientResponse, *args):
             # bypassing process setup by setting qop directly
-            self.mechanism.qop = 'auth'
+            self.mechanism.qop = b'auth'
             msg = b'msg'
             self.assertIs(self.sasl.wrap(msg), msg)
             self.assertIs(self.sasl.unwrap(msg), msg)
 
-            for qop in ('auth-int', 'auth-conf'):
+            for qop in (b'auth-int', b'auth-conf'):
                 self.mechanism.qop = qop
                 with patch('puresasl.mechanisms.kerberos.authGSSClientResponseConf', return_value=1):
                     self.assertEqual(self.sasl.wrap(msg), base64.b64decode(authGSSClientResponse.return_value))
                     self.assertEqual(self.sasl.unwrap(msg), base64.b64decode(authGSSClientResponse.return_value))
-                if qop == 'auth-conf':
+                if qop == b'auth-conf':
                     with patch('puresasl.mechanisms.kerberos.authGSSClientResponseConf', return_value=0):
                         self.assertRaises(Exception, self.sasl.unwrap, msg)
 


### PR DESCRIPTION
Since #12 QOP options have been made python3 compatible, but GSSMechanism did not change with the update. 

This will cause `self.qop != 'auth'` and the others to always evaluate as True in Python3. 