### PR TITLE
Fix Typo in "basic Example"?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Example Usage
 
     # begin normal communication
     encoded = conn.fetch_data()
-    decoded = sasl.unwrap(decoded)
+    decoded = sasl.unwrap(encoded)
     response = process_data(decoded)
     conn.send_data(sasl.wrap(response))
 


### PR DESCRIPTION
"To decode encoded data" instead of "To decode decoded data".

I'm not sure if this is what you actually meant, I'm just guessing as I was literally just passing by.

But if this is not right, another example would probably be good to clear up the misunderstanding:)