### PR TITLE
bufix for kerberos.authGSSClientWrap usage in python3

### DIFF
--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -562,7 +562,7 @@ class GSSAPIMechanism(Mechanism):
                 protect = 1
             else:
                 protect = 0
-            kerberos.authGSSClientWrap(self.context, outgoing, None, protect)
+            kerberos.authGSSClientWrap(self.context, outgoing.decode('utf8'), None, protect)
             return base64.b64decode(kerberos.authGSSClientResponse(self.context))
         else:
             return outgoing


### PR DESCRIPTION
The second parameter only accept, while the result of `base64.b64encode` in python3 is bytes.