### PR TITLE
Wrap and Unwrap has a message length header in GSSAPI implementation

### DIFF
--- a/puresasl/mechanisms.py
+++ b/puresasl/mechanisms.py
@@ -563,11 +563,13 @@ class GSSAPIMechanism(Mechanism):
             else:
                 protect = 0
             kerberos.authGSSClientWrap(self.context, outgoing.decode('utf8'), None, protect)
-            return base64.b64decode(kerberos.authGSSClientResponse(self.context))
-        else:
-            return outgoing
+            outgoing = base64.b64decode(kerberos.authGSSClientResponse(self.context))
+        header = struct.pack('!I', len(outgoing))
+        return header + outgoing
 
     def unwrap(self, incoming):
+        incoming_len, = struct.unpack('!I', incoming[:4])
+        incoming = incoming[4:4+incoming_len]
         if self.qop != QOP.AUTH:
             incoming = base64.b64encode(incoming).decode('ascii')
             kerberos.authGSSClientUnwrap(self.context, incoming)


### PR DESCRIPTION
In my tests and while comparing with native `sasl` library I found out that `GSSAPIMechanism` isn't adding/removing the message length header when wrapping/unwrapping the data.

I wasn't able to confirm if that's according to specs, but it worked with my Hive Metastore Thrift protocol implementation.